### PR TITLE
Remove PHP4 style constructor

### DIFF
--- a/enduser.php
+++ b/enduser.php
@@ -40,7 +40,7 @@ class Virtualizor_Enduser_API {
 	 * @param        int $port (Optional) The port to connect to. Port 4083 is the default. 4082 is non-SSL
 	 * @return       NULL
 	 */
-	function Virtualizor_Enduser_API($ip, $key, $pass, $port = 4083){
+	function __construct($ip, $key, $pass, $port = 4083){
 		$this->key = $key;
 		$this->pass = $pass;
 		$this->ip = $ip;


### PR DESCRIPTION
As per the [Admin SDK PR](https://github.com/virtualizor/Admin_SDK/pull/1), please consider upgrading to PHP 5 constructors. PHP 4 is ancient and the old constructor style is now [deprecated](http://php.net/manual/en/migration70.deprecated.php).
